### PR TITLE
v0.0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,13 +62,12 @@ When built, both projects produce artifacts in the same dir. (for example `Siofr
 Build this as a regular Visual Studio project, copy the artifacts from solution #1 next to the newly built binaries and you are all set to use/further develop the app.
 
 ## Roadmap & Known Bugs [things I am already working on - not in this particular order :) ]
-1. Bigger files (10+ minutes long) take up to 10s to start playing and sometimes pause all sounds for a short period.
-2. Deleting entries from the table and/or clearing the sound file field for a certain entry.
-3. Fix fade-in/fade-out for non-looping sounds (it has proven much more complicated than I imagined)
-4. Implement proper fade-in/fade-out for looping sounds (only first playback fades in - only last playback fades out)
-5. Import doesn't work if you already have another imported package open. 
-#### WORKAROUND: First do File->New, then go to File->Import
-6. Cuttoff range check & message for the user
-7. Mixer volume view of all sounds (maybe some gain settings) 
-8. A help page inside the app (this should be the first in the list I know!)
-7. Interface with Lifx for light sync with music. (PoC in progress)
+1. Fix fade-in/fade-out for non-looping sounds (it has proven much more complicated than I imagined)
+2. Implement proper fade-in for looping sounds (only first playback fades in - only last playback fades out)
+3. Cuttoff range check & message for the user
+4. Mixer volume view of all sounds (maybe some gain settings) 
+5. A help page inside the app (this should be the first in the list I know!)
+6. Interface with Lifx for light sync with music. (PoC in progress)
+
+Please report any issues you come accross, here on github. You can also attach the application logs so that I can see what the errors were. 
+Logs are located in the place you installed the application at. Look for files with names of this example format: "Log-10-27-2023.txt"

--- a/SiofriaSoundboard/SiofriaSoundboard/AudioStuff/Effect.cs
+++ b/SiofriaSoundboard/SiofriaSoundboard/AudioStuff/Effect.cs
@@ -68,6 +68,7 @@ namespace SiofriaSoundboard.AudioStuff
                 paramsChanged = false;
             }
             var samplesAvailable = source.Read(samples, offset, count);
+
             Block(samplesAvailable);
             if (WaveFormat.Channels == 1)
             {

--- a/SiofriaSoundboard/SiofriaSoundboard/AudioStuff/LoopingFadeOutManager.cs
+++ b/SiofriaSoundboard/SiofriaSoundboard/AudioStuff/LoopingFadeOutManager.cs
@@ -1,0 +1,77 @@
+﻿using NAudio.Wave;
+using NAudio.Wave.SampleProviders;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SiofriaSoundboard.AudioStuff
+{
+    internal class LoopingFadeOutManager
+    {
+        private ConcurrentDictionary<SoundClip, float> fadeoutClips;
+        private int fadeOutRate; //ms
+        private Thread thread = null;
+
+        public LoopingFadeOutManager(int fadeOutRate = 100) 
+        {
+            fadeoutClips = new ConcurrentDictionary<SoundClip, float>();
+            this.fadeOutRate = fadeOutRate;
+        }
+
+        public void FadeOutThread()
+        {
+            while (true)
+            {
+                List<KeyValuePair<SoundClip, float>> doneList = new ();
+                foreach (var clip in fadeoutClips)
+                {
+                    VolumeSampleProvider volSampler = clip.Key.GetVolumeSampleProvider();
+
+                    if (volSampler.Volume <= 0)
+                    {
+                        doneList.Add(clip);
+                        continue;
+                    }
+
+                    if (volSampler.Volume < clip.Value)
+                        volSampler.Volume = 0;
+                    else
+                        volSampler.Volume -= clip.Value;
+                }
+
+                foreach (var clipPair in doneList)
+                {
+                    fadeoutClips.TryRemove(clipPair);
+                    SoundClip clip = clipPair.Key;
+                    clip.GetVolumeSampleProvider().Volume = clip.Volume;
+                    clip.Dispose();
+                }
+
+                Thread.Sleep(fadeOutRate);
+            }
+        }
+
+        public void QueueClipForFadeout(SoundClip clip)
+        {
+            float fadeoutTime = clip.FadeOutAmount*1000.0f;
+            float fadeoutSteps = fadeoutTime / fadeOutRate;
+            float amountEachStep = clip.GetVolumeSampleProvider().Volume / fadeoutSteps;
+
+            fadeoutClips.TryAdd(clip, amountEachStep);
+
+            if(thread == null)
+            {
+                thread = new Thread(FadeOutThread);
+                thread.Start();
+            }
+        }
+
+        public void CancelClipFadeout(SoundClip clip)
+        {
+
+        }
+    }
+}

--- a/SiofriaSoundboard/SiofriaSoundboard/Forms/AudioFileCfg.Designer.cs
+++ b/SiofriaSoundboard/SiofriaSoundboard/Forms/AudioFileCfg.Designer.cs
@@ -28,6 +28,7 @@
         /// </summary>
         private void InitializeComponent()
         {
+            components = new System.ComponentModel.Container();
             cb_loop = new CheckBox();
             tracker_volume = new TrackBar();
             cb_fadeout = new CheckBox();
@@ -54,6 +55,9 @@
             tableLayoutPanel3 = new TableLayoutPanel();
             button1 = new Button();
             tableLayoutPanel2 = new TableLayoutPanel();
+            toolTip1 = new ToolTip(components);
+            groupBox4 = new GroupBox();
+            cb_stream = new CheckBox();
             ((System.ComponentModel.ISupportInitialize)tracker_volume).BeginInit();
             groupBox1.SuspendLayout();
             gr_range.SuspendLayout();
@@ -62,13 +66,14 @@
             tableLayoutPanel1.SuspendLayout();
             tableLayoutPanel3.SuspendLayout();
             tableLayoutPanel2.SuspendLayout();
+            groupBox4.SuspendLayout();
             SuspendLayout();
             // 
             // cb_loop
             // 
             cb_loop.Anchor = AnchorStyles.None;
             cb_loop.AutoSize = true;
-            cb_loop.Location = new Point(226, 42);
+            cb_loop.Location = new Point(41, 31);
             cb_loop.Name = "cb_loop";
             cb_loop.Size = new Size(53, 19);
             cb_loop.TabIndex = 0;
@@ -254,6 +259,7 @@
             bt_preview.Size = new Size(92, 42);
             bt_preview.TabIndex = 0;
             bt_preview.Text = "Apply";
+            toolTip1.SetToolTip(bt_preview, "Apply changes [Enter on soundboard]");
             bt_preview.UseVisualStyleBackColor = true;
             bt_preview.Click += button1_Click;
             // 
@@ -349,14 +355,39 @@
             tableLayoutPanel2.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 45.0920258F));
             tableLayoutPanel2.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 200F));
             tableLayoutPanel2.Controls.Add(groupBox1, 0, 0);
-            tableLayoutPanel2.Controls.Add(cb_loop, 1, 0);
             tableLayoutPanel2.Controls.Add(gr_range, 2, 0);
+            tableLayoutPanel2.Controls.Add(groupBox4, 1, 0);
             tableLayoutPanel2.Location = new Point(3, 3);
             tableLayoutPanel2.Name = "tableLayoutPanel2";
             tableLayoutPanel2.RowCount = 1;
             tableLayoutPanel2.RowStyles.Add(new RowStyle(SizeType.Percent, 50F));
             tableLayoutPanel2.Size = new Size(527, 103);
             tableLayoutPanel2.TabIndex = 0;
+            // 
+            // groupBox4
+            // 
+            groupBox4.Controls.Add(cb_stream);
+            groupBox4.Controls.Add(cb_loop);
+            groupBox4.Location = new Point(182, 3);
+            groupBox4.Name = "groupBox4";
+            groupBox4.Size = new Size(141, 97);
+            groupBox4.TabIndex = 8;
+            groupBox4.TabStop = false;
+            groupBox4.Text = "Playback";
+            groupBox4.Enter += groupBox4_Enter;
+            // 
+            // cb_stream
+            // 
+            cb_stream.AutoSize = true;
+            cb_stream.Checked = true;
+            cb_stream.CheckState = CheckState.Checked;
+            cb_stream.Location = new Point(41, 63);
+            cb_stream.Name = "cb_stream";
+            cb_stream.Size = new Size(63, 19);
+            cb_stream.TabIndex = 1;
+            cb_stream.Text = "Stream";
+            cb_stream.UseVisualStyleBackColor = true;
+            cb_stream.CheckedChanged += cb_stream_CheckedChanged;
             // 
             // AudioFileCfg
             // 
@@ -379,7 +410,8 @@
             tableLayoutPanel1.ResumeLayout(false);
             tableLayoutPanel3.ResumeLayout(false);
             tableLayoutPanel2.ResumeLayout(false);
-            tableLayoutPanel2.PerformLayout();
+            groupBox4.ResumeLayout(false);
+            groupBox4.PerformLayout();
             ResumeLayout(false);
         }
 
@@ -411,5 +443,8 @@
         private Button button1;
         private TextBox tb_end;
         private Label label2;
+        private ToolTip toolTip1;
+        private GroupBox groupBox4;
+        private CheckBox cb_stream;
     }
 }

--- a/SiofriaSoundboard/SiofriaSoundboard/Forms/AudioFileCfg.cs
+++ b/SiofriaSoundboard/SiofriaSoundboard/Forms/AudioFileCfg.cs
@@ -35,6 +35,7 @@ namespace SiofriaSoundboard
             clip.FadeInEnabled = cb_fadein.Checked;
             clip.FadeOutEnabled = cb_fadeout.Checked;
             clip.Loop = cb_loop.Checked;
+            clip.Stream = cb_stream.Checked;
 
             try
             {
@@ -58,7 +59,7 @@ namespace SiofriaSoundboard
             cb_fadein.Checked = clip.FadeInEnabled;
             cb_fadeout.Checked = clip.FadeOutEnabled;
             cb_loop.Checked = clip.Loop;
-
+            cb_stream.Checked = clip.Stream;
             tb_start.Text = clip.CutRangeBegin.ToString();
             tb_end.Text = clip.CutRangeTake.ToString();
             tb_fadein.Text = clip.FadeInAmount.ToString();
@@ -67,7 +68,27 @@ namespace SiofriaSoundboard
 
         private void checkBox1_CheckedChanged(object sender, EventArgs e)
         {
+            if (cb_loop.Checked) //disable unsupported combinations of settings
+            {
+                clip.CutRangeEnabled = false;
+                clip.FadeInEnabled = false;
+                cb_cut_enabled.Enabled = false;
+                cb_fadein.Enabled = false;
+                tb_start.Enabled = false;
+                tb_end.Enabled = false;
+                tb_fadein.Enabled = false;
+            }
+            else
+            {
+                clip.CutRangeEnabled = cb_cut_enabled.Checked;
+                clip.FadeInEnabled = cb_fadein.Checked;
 
+                cb_cut_enabled.Enabled = true;
+                cb_fadein.Enabled = true;
+                tb_start.Enabled = true;
+                tb_end.Enabled = true;
+                tb_fadein.Enabled = true;
+            }
         }
 
         private void groupBox1_Enter(object sender, EventArgs e)
@@ -207,6 +228,16 @@ namespace SiofriaSoundboard
                 e.Effect = DragDropEffects.Copy; // Okay
             else
                 e.Effect = DragDropEffects.None; // Unknown data, ignore it
+        }
+
+        private void groupBox4_Enter(object sender, EventArgs e)
+        {
+
+        }
+
+        private void cb_stream_CheckedChanged(object sender, EventArgs e)
+        {
+
         }
     }
 }

--- a/SiofriaSoundboard/SiofriaSoundboard/Forms/AudioFileCfg.resx
+++ b/SiofriaSoundboard/SiofriaSoundboard/Forms/AudioFileCfg.resx
@@ -120,4 +120,10 @@
   <metadata name="openFileDialog1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
+  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>156, 17</value>
+  </metadata>
+  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>156, 17</value>
+  </metadata>
 </root>

--- a/SiofriaSoundboard/SiofriaSoundboard/Forms/Form1.Designer.cs
+++ b/SiofriaSoundboard/SiofriaSoundboard/Forms/Form1.Designer.cs
@@ -53,6 +53,7 @@
             cb_Play = new CheckBox();
             saveFileDialog1 = new SaveFileDialog();
             timercolor = new System.Windows.Forms.Timer(components);
+            toolTip1 = new ToolTip(components);
             ((System.ComponentModel.ISupportInitialize)splitContainer1).BeginInit();
             splitContainer1.Panel1.SuspendLayout();
             splitContainer1.SuspendLayout();
@@ -104,6 +105,7 @@
             dataGridView1.Size = new Size(236, 417);
             dataGridView1.TabIndex = 0;
             dataGridView1.CellClick += dataGridView1_CellContentClick;
+            dataGridView1.KeyDown += dataGridView1_KeyDown;
             // 
             // statusStrip1
             // 
@@ -272,6 +274,7 @@
             button1.Size = new Size(70, 25);
             button1.TabIndex = 3;
             button1.Text = "STOP!";
+            toolTip1.SetToolTip(button1, "Stop all playback [backspace on soundboard]");
             button1.UseVisualStyleBackColor = true;
             button1.Click += button1_Click;
             // 
@@ -288,6 +291,7 @@
             cb_Play.Size = new Size(48, 25);
             cb_Play.TabIndex = 2;
             cb_Play.Text = "Play!";
+            toolTip1.SetToolTip(cb_Play, "Toggle to enable soundboard mode");
             cb_Play.UseVisualStyleBackColor = true;
             cb_Play.CheckedChanged += cb_Play_CheckedChanged;
             // 
@@ -350,5 +354,6 @@
         private ToolStripMenuItem toolStripMenuItem1;
         private System.Windows.Forms.Timer timercolor;
         private Button button1;
+        private ToolTip toolTip1;
     }
 }

--- a/SiofriaSoundboard/SiofriaSoundboard/Forms/Form1.resx
+++ b/SiofriaSoundboard/SiofriaSoundboard/Forms/Form1.resx
@@ -129,6 +129,9 @@
   <metadata name="fileCheckTimer.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>382, 17</value>
   </metadata>
+  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>759, 17</value>
+  </metadata>
   <metadata name="saveFileDialog1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>515, 17</value>
   </metadata>

--- a/SiofriaSoundboard/SiofriaSoundboard/Network/UpdateChecker.cs
+++ b/SiofriaSoundboard/SiofriaSoundboard/Network/UpdateChecker.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Net.Http;
+using Newtonsoft.Json.Linq;
+using Microsoft.VisualBasic.Logging;
+
+namespace SiofriaSoundboard.Network
+{
+    class UpdateChecker
+    {
+        private static readonly String tag = "v0.0.3";
+        private static readonly HttpClient client = new HttpClient();
+
+
+        private static bool CheckRepoVersionBigger(String repoVersion)
+        {
+            string version1 = tag.Substring(1);
+            string version2 = repoVersion.Substring(1);
+
+            // Create Version objects
+            Version v1 = new Version(version1);
+            Version v2 = new Version(version2);
+
+            // Compare versions
+            int comparison = v1.CompareTo(v2);
+
+            return comparison < 0;
+        }
+
+        public static async void CheckForNewVersionAsync()
+        {
+            try
+            {
+                client.DefaultRequestHeaders.Add("Accept", "application/vnd.github+json");
+                client.DefaultRequestHeaders.Add("X-GitHub-Api-Version", "2022-11-28");
+                client.DefaultRequestHeaders.UserAgent.Add(new System.Net.Http.Headers.ProductInfoHeaderValue("curl", "7.46.0"));
+
+                HttpResponseMessage response = await client.GetAsync("https://api.github.com/repos/BarlowTheKeeper/SiofriaSoundboardProject/releases");
+                response.EnsureSuccessStatusCode();
+                string responseBody = await response.Content.ReadAsStringAsync();
+
+                JArray releases = JArray.Parse(responseBody);
+                foreach (JObject release in releases)
+                {
+                    String repoRelease = release["tag_name"].ToString();
+                    if (CheckRepoVersionBigger(repoRelease))
+                        MessageBox.Show("New version " + repoRelease + " available on Github!\n Visit: https://github.com/BarlowTheKeeper/SiofriaSoundboardProject/releases to download it.");
+                }
+            }
+            catch (HttpRequestException e)
+            {
+                Utils.Log.Write(e.Message);
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
fix: Big looping audio files freeze audio output for a couple of seconds
fix: Importing stuff after another package was already imported
feat: Gray out unsupported features when looping is checked for a sound
feat: Tooltips for Stop/Play/Apply
feat: Use the delete key to remove entries from the sound-mapping table
feat: Audio files can be streamed every time they are played or loaded once into memory and played from there (useful for different filesizes)
feat: App checks for newer Github releases and informs the user there is a new version available.
feat: Proper fadeout for looping sounds (still in a test phase)

All packages from v0.0.2 should be compatible with the new version (v0.0.3)

PS I promise I will stop doing these monolith pushes and start doing a PR per feature/fix
I will use this PR as a "hot diff" until I am sure I won't change anything else in this version...feel free to comment until then